### PR TITLE
Simplify multiprocessing routine for streaming execution

### DIFF
--- a/src/nite/audio/audio_action.py
+++ b/src/nite/audio/audio_action.py
@@ -131,13 +131,11 @@ class AudioActions(AudioAction):
     def set_features(self, audio_sample_features: AudioSampleFeatures) -> None:
         for action in self.actions:
             if isinstance(action, AudioActionBPM):
-                if audio_sample_features.bpm is None:
-                    raise InvalidAudioFeatureError("Cannnot set BPM to None")
-                action.set_bpm(audio_sample_features.bpm)
+                if audio_sample_features.bpm is not None:
+                    action.set_bpm(audio_sample_features.bpm)
             elif isinstance(action, AudioActionPitch):
-                if audio_sample_features.pitches is None:
-                    raise InvalidAudioFeatureError("Cannnot set pitches to None")
-                action.set_pitches(audio_sample_features.pitches)
+                if audio_sample_features.pitches is not None:
+                    action.set_pitches(audio_sample_features.pitches)
 
     async def act(self, time_in_ms: int) -> Tuple[bool, float]:
         tasks = []

--- a/src/nite/audio/audio_io.py
+++ b/src/nite/audio/audio_io.py
@@ -11,7 +11,7 @@ from nite.audio.audio_action import AudioActions
 from nite.audio.audio_processing import AudioProcessor, AudioSampleFeatures
 from nite.config import AUDIO_CHANNELS, AUDIO_SAMPLING_RATE
 from nite.logging import configure_module_logging
-from nite.video_mixer import QueueHandler, TimeRecorder
+from nite.video_mixer import TimeRecorder
 
 logger = configure_module_logging("nite.audio_listener")
 
@@ -19,64 +19,63 @@ logger = configure_module_logging("nite.audio_listener")
 class AudioListener:
     def __init__(
         self,
-        queue_handler: QueueHandler,
         audio_processor: AudioProcessor,
         audio_actions: AudioActions,
+        actions_queue: asyncio.Queue,
         audio_format: AudioFormat = short_format,
         sample_rate: int = AUDIO_SAMPLING_RATE,
         audio_channels: int = AUDIO_CHANNELS,
     ) -> None:
-        self.queue_handler = queue_handler
-        self.audio_processor = audio_processor
-        self.audio_format = audio_format
-        self.sample_rate = sample_rate
-        self.audio_channels = audio_channels
-        self.audio_actions = audio_actions
-        self.audio_processor.set_sampling_rate(sample_rate)
-        self.time_recorder = TimeRecorder()
-        logger.info(f"Loaded audio listener. Format: {self.audio_format}")
+        self._audio_processor = audio_processor
+        self._audio_format = audio_format
+        self._sample_rate = sample_rate
+        self._audio_channels = audio_channels
+        self._audio_actions = audio_actions
+        self._actions_queue = actions_queue
+        self._audio_processor.set_sampling_rate(sample_rate)
+        self._time_recorder = TimeRecorder()
+        logger.info(f"Loaded audio listener. Format: {self._audio_format}")
 
     async def _get_audio_sample_features(self, audio_sample: np.ndarray) -> AudioSampleFeatures:
-        audio_sample_features = await self.audio_processor.process_audio_sample(audio_sample)
+        audio_sample_features = await self._audio_processor.process_audio_sample(audio_sample)
         return audio_sample_features
 
     def _process_audio_block(self, in_data, frame_count, time_info, status):
         audio_sample = np.array(
-            struct.unpack(self.audio_format.unpack_format % frame_count, in_data)
+            struct.unpack(self._audio_format.unpack_format % frame_count, in_data)
         )
         audio_sample_features = asyncio.run(self._get_audio_sample_features(audio_sample))
-        self.audio_actions.set_features(audio_sample_features)
+        self._audio_actions.set_features(audio_sample_features)
         should_do_action, blend_strength = asyncio.run(
-            self.audio_actions.act(self.time_recorder.elapsed_time_in_ms_since_last_asked)
+            self._audio_actions.act(self._time_recorder.elapsed_time_in_ms_since_last_asked)
         )
         if should_do_action:
-            self.queue_handler.send_blend_strength(blend_strength)
+            self._actions_queue.put(blend_strength)
         return in_data, pyaudio.paContinue
 
-    def start(self) -> None:
+    async def start(self) -> None:
         paud = pyaudio.PyAudio()
         stream = paud.open(
-            format=self.audio_format.pyaudio_format,
-            channels=self.audio_channels,
-            rate=self.sample_rate,
+            format=self._audio_format.pyaudio_format,
+            channels=self._audio_channels,
+            rate=self._sample_rate,
             input=True,
             stream_callback=self._process_audio_block,
         )
 
         logger.info("Starting audio listening")
-        self.time_recorder.start_recording_if_not_started()
-        while stream.is_active():
-            should_terminate, _ = self.queue_handler.receive_blend_strength()
-            if should_terminate:
-                logger.info("Audio Listener stopped by terminate message")
-                break
+        self._time_recorder.start_recording_if_not_started()
 
-            if self.time_recorder.has_period_passed:
-                logger.info(f"Keep-alive. Elapsed time: {self.time_recorder.elapsed_time_str}")
-
-        stream.close()
-        paud.terminate()
-        logger.info(f"Audio listening stopped. Elapsed time: {self.time_recorder.elapsed_time_str}")
+        try:
+            # Keep the stream alive. The callback function will handle the audio processing.
+            while stream.is_active():
+                if self._time_recorder.has_period_passed:
+                    logger.info(f"Keep-alive. Elapsed time: {self._time_recorder.elapsed_time_str}")
+        except asyncio.CancelledError:
+            logger.info(f"Audio listening stopped. Elapsed time: {self._time_recorder.elapsed_time_str}")
+        finally:
+            stream.close()
+            paud.terminate()
 
 
 class AudioAnalyzerSong:

--- a/src/nite/cli/video_mixer.py
+++ b/src/nite/cli/video_mixer.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import wraps
 from pathlib import Path
 
 import click
@@ -197,7 +198,7 @@ def stream(ctx, playback_time_sec):
         playback_time_sec=playback_time_sec,
     )
     video_combiner = asyncio.run(video_combiner_factory.get_stream_config())
-    video_combiner.stream()
+    asyncio.run(video_combiner.stream())
 
 
 def main():

--- a/src/nite/cli/video_mixer.py
+++ b/src/nite/cli/video_mixer.py
@@ -1,5 +1,4 @@
 import asyncio
-from functools import wraps
 from pathlib import Path
 
 import click
@@ -198,7 +197,7 @@ def stream(ctx, playback_time_sec):
         playback_time_sec=playback_time_sec,
     )
     video_combiner = asyncio.run(video_combiner_factory.get_stream_config())
-    asyncio.run(video_combiner.stream())
+    video_combiner.stream()
 
 
 def main():

--- a/src/nite/logging.py
+++ b/src/nite/logging.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import logging.config
 import logging.handlers
-import warnings
 
 from nite.config import LOGGING_LEVEL
 
@@ -28,7 +27,6 @@ config_dictionary = {
 
 def configure_module_logging(logger_name: str):
     # Disable warnings. Librosa emits a lot of UserWarnings that are not relevant.
-    warnings.filterwarnings("ignore")
     logger_config = copy.deepcopy(config_dictionary)
     logging.config.dictConfig(logger_config)
     logger = logging.getLogger(logger_name)

--- a/src/nite/video_mixer/__init__.py
+++ b/src/nite/video_mixer/__init__.py
@@ -1,14 +1,10 @@
 import time
 from datetime import timedelta
-from enum import Enum
-from multiprocessing import Queue
-from queue import Empty as QueueEmpty
-from typing import List, Optional, Tuple, Union
+from typing import Optional
 
-import numpy as np
-from pydantic import BaseModel, ValidationInfo, computed_field, field_validator
+from pydantic import BaseModel, computed_field, field_validator
 
-from nite.config import KEEPALIVE_TIMEOUT, TERMINATE_MESSAGE
+from nite.config import KEEPALIVE_TIMEOUT
 from nite.logging import configure_module_logging
 
 LOGGING_NAME = "nite.video_mixer"
@@ -16,10 +12,6 @@ logger = configure_module_logging(LOGGING_NAME)
 
 
 class TimeRecorderError(Exception):
-    pass
-
-
-class QueueHandlerError(Exception):
     pass
 
 
@@ -81,110 +73,3 @@ class TimeRecorder(BaseModel):
         elapsed_time = new_time_asked - self.time_from_last_asked
         self.time_from_last_asked = new_time_asked
         return elapsed_time * 1000
-
-
-class MessageConentType(str, Enum):
-    message = "message"
-    audio_sample = "audio_sample"
-    blend_strength = "blend_strength"
-
-
-class Message(BaseModel):
-    content_type: MessageConentType
-    content: Union[str, List[float], float]
-
-    @field_validator("content")
-    @classmethod
-    def content_respects_type(cls, content, info: ValidationInfo):
-        if "content_type" not in info.data:
-            raise ValueError("Message content_type must be defined")
-
-        if info.data["content_type"] == MessageConentType.message and not isinstance(content, str):
-            raise ValueError("Message content must be a string as content_type is message")
-
-        if info.data["content_type"] == MessageConentType.audio_sample:
-            try:
-                content_npy = np.array(content)
-            except Exception:
-                raise ValueError(
-                    "content_type = audio_sample: Content must be transformable to a numpy array"
-                )
-
-            if not np.issubdtype(content_npy.dtype, np.number):
-                raise ValueError("content_type = audio_sample. Content must be a float array")
-
-        if info.data["content_type"] == MessageConentType.blend_strength and not isinstance(
-            content, float
-        ):
-            raise ValueError("Message content must be a float as content_type is blend_strength")
-
-        return content
-
-
-class QueueHandler:
-    def __init__(self, in_queue: Queue, out_queue: Queue) -> None:
-        self.in_queue = in_queue
-        self.out_queue = out_queue
-
-    def _receive_from_queue(self) -> Optional[Message]:
-        try:
-            message = self.in_queue.get(block=False)
-            return message
-        except QueueEmpty:
-            pass
-        return None
-
-    def send_message(self, message: str) -> None:
-        message_obj = Message(content_type=MessageConentType.message, content=message)
-        self.out_queue.put(message_obj)
-
-    def send_audio_sample(self, audio_sample: np.ndarray) -> None:
-        message_obj = Message(
-            content_type=MessageConentType.audio_sample, content=audio_sample.tolist()
-        )
-        self.out_queue.put(message_obj)
-
-    def send_blend_strength(self, blend_strength: float) -> None:
-        message_obj = Message(content_type=MessageConentType.blend_strength, content=blend_strength)
-        self.out_queue.put(message_obj)
-
-    def receive_audio_sample(self) -> Tuple[bool, Optional[np.ndarray]]:
-        message_obj = self._receive_from_queue()
-        if not message_obj:
-            return False, None
-
-        if message_obj.content_type == MessageConentType.audio_sample:
-            return False, np.array(message_obj.content)
-
-        if message_obj.content_type == MessageConentType.message:
-            return self.should_terminate(str(message_obj.content)), None
-
-        return False, None
-
-    def receive_blend_strength(self) -> Tuple[bool, Optional[float]]:
-        message_obj = self._receive_from_queue()
-        if not message_obj:
-            return False, 0.0
-
-        if message_obj.content_type == MessageConentType.blend_strength:
-            if not isinstance(message_obj.content, float):
-                raise QueueHandlerError(
-                    "Message content must be a float as content_type is blend_strength"
-                )
-            return False, message_obj.content
-
-        if message_obj.content_type == MessageConentType.message:
-            return self.should_terminate(str(message_obj.content)), None
-
-        return False, None
-
-    def should_terminate(self, message: str) -> bool:
-        if message == TERMINATE_MESSAGE:
-            return True
-        return False
-
-    def cleanup(self) -> None:
-        self.in_queue.close()
-        self.out_queue.close()
-        self.in_queue.cancel_join_thread()
-        self.out_queue.cancel_join_thread()

--- a/src/nite/video_mixer/factories.py
+++ b/src/nite/video_mixer/factories.py
@@ -1,6 +1,5 @@
 import asyncio
 from abc import ABC, abstractmethod
-from multiprocessing import Queue
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -22,7 +21,6 @@ from nite.video.video_io import NiteVideo, VideoStream
 from nite.video_mixer.blender import BlenderMath, BlendModes, BlendWithSong
 from nite.video_mixer.buffers import SampleBuffer
 from nite.video_mixer.streamer import (
-    QueueHandler,
     VideoCombinerAudioListenerQueue,
     VideoCombinerQueue,
     VideoCombinerSong,
@@ -98,7 +96,7 @@ class AudioFactory(NiteFactory):
         min_pitch: Optional[int],
         max_pitch: Optional[int],
         blend_falloff: float,
-        queue_handler: Optional[QueueHandler] = None,
+        actions_queue: Optional[asyncio.Queue] = None,
     ) -> None:
         self._validate_settings(bpm_frequency, min_pitch, max_pitch)
         self.bpm_action = None
@@ -113,7 +111,7 @@ class AudioFactory(NiteFactory):
                 min_pitch=ChromaIndex(min_pitch), max_pitch=ChromaIndex(max_pitch)
             )
 
-        self.queue_handler = queue_handler
+        self._actions_queue = actions_queue
 
     def _validate_settings(
         self,
@@ -150,8 +148,8 @@ class AudioFactory(NiteFactory):
         )
 
     async def get_stream_config(self) -> Tuple[AudioListener, AudioActions]:
-        if self.queue_handler is None:
-            raise InitMixerError("QueueHandler must be set when initializing audio strem.")
+        if self._actions_queue is None:
+            raise InitMixerError("Actions Queue must be set when initializing audio strem.")
         bpm_detector, pitch_detector = None, None
         if self.bpm_action is not None:
             bpm_detector_factory = BPMDetectorFactory(nite_config.AUDIO_SAMPLING_RATE)
@@ -164,7 +162,7 @@ class AudioFactory(NiteFactory):
             bpm_detector, pitch_detector, audio_format=short_format
         )
         return AudioListener(
-            queue_handler=self.queue_handler,
+            actions_queue=self._actions_queue,
             audio_processor=audio_processor,
             audio_actions=audio_actions,
         ), audio_actions
@@ -193,7 +191,7 @@ class VideoFactory(NiteFactory):
         video_2: Path,
         alpha: Path,
         blend_operation: str,
-        queue_handler: Optional[QueueHandler] = None,
+        actions_queue: Optional[asyncio.Queue] = None,
         audio_actions: Optional[AudioActions] = None,
     ) -> None:
         self.width = width
@@ -202,7 +200,7 @@ class VideoFactory(NiteFactory):
         self.video_2 = video_2
         self.alpha = alpha
         self.blend_operation = blend_operation
-        self.queue_handler = queue_handler
+        self._actions_queue = actions_queue
         self.audio_actions = audio_actions
 
     async def _init(self) -> Tuple[List[VideoFramesPath], BlendWithSong]:
@@ -236,10 +234,10 @@ class VideoFactory(NiteFactory):
         return BlendWithSong(blender_math)
 
     async def get_stream_config(self) -> VideoCombinerQueue:
-        if self.queue_handler is None:
-            raise InitMixerError("QueueHandler must be set when initializing video stream.")
+        if self._actions_queue is None:
+            raise InitMixerError("Actions Queue must be set when initializing video stream.")
         videos, blender = await self._init()
-        return VideoCombinerQueue(videos, blender, self.queue_handler)
+        return VideoCombinerQueue(videos, blender, self._actions_queue)
 
     async def get_song_config(self) -> VideoCombinerSong:
         if self.audio_actions is None:
@@ -280,10 +278,8 @@ class VideoCombinerFactory:
     async def get_stream_config(self) -> VideoCombinerAudioListenerQueue:
         if self.playback_time_sec is None:
             raise InitMixerError("Playback time must be set when initializing video stream.")
-        queue_to_video: Queue = Queue()
-        queue_to_audio: Queue = Queue()
-        queue_handler_video = QueueHandler(in_queue=queue_to_video, out_queue=queue_to_audio)
-        queue_handler_audio = QueueHandler(in_queue=queue_to_audio, out_queue=queue_to_video)
+
+        actions_queue = asyncio.Queue()
         video_factory = VideoFactory(
             video_1=self.video_1,
             video_2=self.video_2,
@@ -291,19 +287,19 @@ class VideoCombinerFactory:
             width=self.width,
             height=self.height,
             blend_operation=self.blend_operation,
-            queue_handler=queue_handler_video,
+            actions_queue=actions_queue,
         )
         audio_factory = AudioFactory(
             bpm_frequency=self.bpm_frequency,
             min_pitch=self.min_pitch,
             max_pitch=self.max_pitch,
             blend_falloff=self.blend_falloff,
-            queue_handler=queue_handler_audio,
+            actions_queue=actions_queue,
         )
         video_combiner_queue = await video_factory.get_stream_config()
         audio_listener, _ = await audio_factory.get_stream_config()
         return VideoCombinerAudioListenerQueue(
-            video_combiner_queue, audio_listener, self.playback_time_sec
+            video_combiner_queue, audio_listener, self.playback_time_sec, actions_queue
         )
 
     async def get_song_config(self) -> VideoCombinerSong:


### PR DESCRIPTION
There used to be a `QueueHandler` for bi-directional communication between processes. It was an over-complicated design. After simplification and rewriting of the code we can get away with a single `Queue` shared with a simple Consumer-Producer architecture.